### PR TITLE
Fix error when variable comment has no description and better location o...

### DIFF
--- a/Sniffs/Classes/DuplicatePropertySniff.php
+++ b/Sniffs/Classes/DuplicatePropertySniff.php
@@ -33,7 +33,7 @@ use PHP_CodeSniffer_Sniff;
 class DuplicatePropertySniff implements PHP_CodeSniffer_Sniff
 {
     /**
-     * @var array A list of tokenizers this sniff supports
+     * @var array A list of tokenizers this sniff supports.
      */
     public $supportedTokenizers = ['JS'];
 


### PR DESCRIPTION
after 02669bb05724e0d6823c8497b2f21852828b5f3f There was left undefined index error and when using advanced array hinting comment start was not found correctly .
