### PR TITLE
Update forbiddenFunctions method access.

### DIFF
--- a/Sniffs/PHP/DiscouragedFunctionsSniff.php
+++ b/Sniffs/PHP/DiscouragedFunctionsSniff.php
@@ -39,7 +39,7 @@ class DiscouragedFunctionsSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSni
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = [
+    public $forbiddenFunctions = [
         'error_log' => null,
         'print_r' => null,
         'var_dump' => null,

--- a/Sniffs/PHP/ForbiddenFunctionsSniff.php
+++ b/Sniffs/PHP/ForbiddenFunctionsSniff.php
@@ -42,7 +42,7 @@ class ForbiddenFunctionsSniff extends Generic_Sniffs_PHP_ForbiddenFunctionsSniff
      *
      * @var array(string => string|null)
      */
-    protected $forbiddenFunctions = [
+    public $forbiddenFunctions = [
         'sizeof' => 'count',
         'delete' => 'unset',
         'print' => 'echo',


### PR DESCRIPTION
PHP_CodeSniffer version 2.1.0 (stable) by Squiz (http://www.squiz.net) throws errors when forbiddenFunctions isn't public.
```
PHP Fatal error:  Access level to ONGR\Sniffs\PHP\DiscouragedFunctionsSniff::$forbiddenFunctions must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff) in /vagrant/LumberJack/vendor/ongr/ongr-strict-standard/ONGR/Sniffs/PHP/DiscouragedFunctionsSniff.php on line 33
```
```
PHP Fatal error:  Access level to ONGR\Sniffs\PHP\ForbiddenFunctionsSniff::$forbiddenFunctions must be public (as in class Generic_Sniffs_PHP_ForbiddenFunctionsSniff) in /vagrant/LumberJack/vendor/ongr/ongr-strict-standard/ONGR/Sniffs/PHP/ForbiddenFunctionsSniff.php on line 65
```