### PR TITLE
Exclude already overridden sniff.

### DIFF
--- a/Ongr/ruleset.xml
+++ b/Ongr/ruleset.xml
@@ -42,6 +42,7 @@
      <exclude name="Squiz.PHP.DisallowBooleanStatement"/>
      <exclude name="Squiz.PHP.DisallowComparisonAssignment"/>
      <exclude name="Squiz.PHP.DisallowInlineIf"/>
+     <exclude name="Squiz.PHP.DisallowMultipleAssignments"/>
      <exclude name="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
      <exclude name="Squiz.PHP.Eval"/>
      <exclude name="Squiz.PHP.Heredoc"/>


### PR DESCRIPTION
This was overridden here https://github.com/ongr-io/ongr-strict-standard/blob/d4567d5e00dd060e39e122bc9b09a0c666882f9b/Ongr/Sniffs/PHP/DisallowMultipleAssignmentsSniff.php
Closes #123.