### PR TITLE
Fixed: no longer throws PHP notices on empty function @return comments.

### DIFF
--- a/Ongr/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Ongr/Sniffs/Commenting/FunctionCommentSniff.php
@@ -321,7 +321,7 @@ class Ongr_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
                 $comment = null;
                 if ($tokens[($return + 2)]['code'] === T_DOC_COMMENT_STRING) {
                     $matches = array();
-                    preg_match('/([^\s]+)(?:\s+(.*))?/', $tokens[($return + 2)]['content'], $matches);
+                    preg_match('/([^\s]+)(?:\s+(.+))?/', $tokens[($return + 2)]['content'], $matches);
                     if (isset($matches[2]) === true) {
                         $comment = $matches[2];
                     }
@@ -329,8 +329,7 @@ class Ongr_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
 
                 //ONGR Validate that return comment begins with capital letter and ends with full stop.
                 if ($comment !== null) {
-                    $firstChar = $comment{0};
-                    if (preg_match('|\p{Lu}|u', $firstChar) === 0) {
+                    if (!preg_match('/^\\p{Lu}/u', $comment)) {
                         $error = 'Return comment must start with a capital letter';
                         $fix = $phpcsFile->addFixableError($error, ($return + 2), 'ReturnCommentNotCapital');
 
@@ -345,8 +344,7 @@ class Ongr_Sniffs_Commenting_FunctionCommentSniff extends PEAR_Sniffs_Commenting
                         }
                     }
 
-                    $lastChar = substr($comment, -1);
-                    if ($lastChar !== '.') {
+                    if (!preg_match('/\\.$/u', $comment)) {
                         $error = 'Return comment must end with a full stop';
                         $fix = $phpcsFile->addFixableError($error, ($return + 2), 'ReturnCommentFullStop');
 

--- a/Ongr/Tests/Unit/Commenting/FunctionCommentSniffTest.phptest
+++ b/Ongr/Tests/Unit/Commenting/FunctionCommentSniffTest.phptest
@@ -246,4 +246,16 @@ class FunctionCommentSniffTest
     public function __wakeup()
     {
     }
+
+    /**
+     * Bar.
+     *
+     * Should report only extra whitespace, and no additional errors about the return comment format.
+     *
+     * @return mixed 
+     */
+    protected function fooBar8()
+    {
+        return foo($bar);
+    }
 }


### PR DESCRIPTION
Checker no longer throws PHP notices on empty function @return comments (when @return line ends with whitespace). Also, it no longer incorrectly reports errors about return comment format, when there's simply no return comment.

Fixes #136.